### PR TITLE
Add user report generation module

### DIFF
--- a/src/Neo.Capture.Api/Apis/ReportModule.cs
+++ b/src/Neo.Capture.Api/Apis/ReportModule.cs
@@ -1,0 +1,19 @@
+using LowCodeHub.MinimalEndpoints.Abstractions;
+using LowCodeHub.MinimalEndpoints.Extensions;
+using Neo.Capture.Application.Features.GenerateReport;
+
+namespace Neo.Capture.Apis
+{
+    public class ReportModule : IModule
+    {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            RouteGroupBuilder group = app.MapGroup("/api/report")
+                                      .WithTags("Report")
+                                      .WithGroupName("neo-capture")
+                                      .WithOpenApi();
+
+            group.MapEndpoint<GenerateReportEndpoint>();
+        }
+    }
+}

--- a/src/Neo.Capture.Api/Program.cs
+++ b/src/Neo.Capture.Api/Program.cs
@@ -115,6 +115,8 @@ builder.Services.AddScoped<ILocationService, LocationService>();
 
 builder.Services.AddScoped<ICurrentUserProvider, CurrentUserProvider>();
 
+builder.Services.AddScoped<IReportService, ReportService>();
+
 builder.Services.AddValidators<Program>();
 
 //builder.Services.AddDbContext<NeoCaptureDbContext>(options =>

--- a/src/Neo.Capture.Application/Features/GenerateReport/GenerateReportEndpoint.cs
+++ b/src/Neo.Capture.Application/Features/GenerateReport/GenerateReportEndpoint.cs
@@ -1,0 +1,40 @@
+using ErrorOr;
+using LowCodeHub.MinimalEndpoints.Abstractions;
+using LowCodeHub.MinimalEndpoints.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Neo.Capture.Application.Interfaces.Services;
+using Neo.Capture.Domain.Operation;
+
+namespace Neo.Capture.Application.Features.GenerateReport
+{
+    public sealed class GenerateReportEndpoint(IReportService _reportService) : IMinimalEndpoint<string>
+    {
+        public void AddRoute(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/download", Handle)
+               .Produces(200)
+               .AddLogging<GenerateReportEndpoint>()
+               .WithName("GenerateReport");
+        }
+
+        public async ValueTask<IResult> Handle([FromQuery(Name = "phoneNumber")] string phoneNumber, CancellationToken cancellationToken)
+        {
+            ErrorOr<ReportFile> result = await _reportService.GenerateReportAsync(phoneNumber, cancellationToken);
+
+            if (result.IsError)
+            {
+                return TypedResults.UnprocessableEntity(new EndpointResult
+                {
+                    IsSuccess = false,
+                    ErrorCode = result.FirstError.Code,
+                    ErrorMessage = result.FirstError.Description
+                });
+            }
+
+            return TypedResults.File(result.Value.Content, "application/zip", result.Value.FileName);
+        }
+    }
+}

--- a/src/Neo.Capture.Application/Interfaces/Services/ICloudStorageService.cs
+++ b/src/Neo.Capture.Application/Interfaces/Services/ICloudStorageService.cs
@@ -8,5 +8,6 @@ namespace Neo.Capture.Application.Interfaces.Services
         Task<string> UploadFileAsync(string bucketName, IFormFile file, string customFileName, CancellationToken cancellationToken);
         Task<bool> RemoveFileAsync(string bucketName, string fileName, CancellationToken cancellationToken);
         Task<bool> FileExistsAsync(string bucketName, string fileName, CancellationToken cancellationToken);
+        Task<byte[]> DownloadFileAsync(string bucketName, string fileName, CancellationToken cancellationToken);
     }
 }

--- a/src/Neo.Capture.Application/Interfaces/Services/IReportService.cs
+++ b/src/Neo.Capture.Application/Interfaces/Services/IReportService.cs
@@ -1,0 +1,10 @@
+using ErrorOr;
+namespace Neo.Capture.Application.Interfaces.Services
+{
+    public record ReportFile(byte[] Content, string FileName);
+
+    public interface IReportService
+    {
+        Task<ErrorOr<ReportFile>> GenerateReportAsync(string phoneNumber, CancellationToken cancellationToken);
+    }
+}

--- a/src/Neo.Capture.Infrastructure/Implementations/Services/ICloudStorageService.cs
+++ b/src/Neo.Capture.Infrastructure/Implementations/Services/ICloudStorageService.cs
@@ -123,5 +123,25 @@ namespace Neo.Capture.Infrastructure.Implementations.Services
                 throw new InvalidOperationException($"Failed to check if file {fileName} exists in bucket {bucketName}", ex);
             }
         }
+
+        public async Task<byte[]> DownloadFileAsync(string bucketName, string fileName, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(bucketName))
+                throw new ArgumentException("Bucket name cannot be null or empty", nameof(bucketName));
+
+            if (string.IsNullOrWhiteSpace(fileName))
+                throw new ArgumentException("File name cannot be null or empty", nameof(fileName));
+
+            try
+            {
+                using MemoryStream stream = new();
+                await _storageClient.DownloadObjectAsync(bucketName, fileName, stream, cancellationToken: cancellationToken);
+                return stream.ToArray();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to download file {fileName} from bucket {bucketName}", ex);
+            }
+        }
     }
 }

--- a/src/Neo.Capture.Infrastructure/Implementations/Services/ReportService.cs
+++ b/src/Neo.Capture.Infrastructure/Implementations/Services/ReportService.cs
@@ -1,0 +1,98 @@
+using System.IO.Compression;
+using System.Text;
+using System.Collections.Concurrent;
+using ErrorOr;
+using Microsoft.EntityFrameworkCore;
+using Neo.Capture.Application.Interfaces.Repositories;
+using Neo.Capture.Application.Interfaces.Services;
+using Neo.Capture.Domain.Entities;
+
+namespace Neo.Capture.Infrastructure.Implementations.Services
+{
+    public sealed class ReportService(
+        NeoCaptureDbContext _dbContext,
+        IProfileRepository _profileRepo,
+        ICloudStorageService _storageService) : IReportService
+    {
+        public async Task<ErrorOr<ReportFile>> GenerateReportAsync(string phoneNumber, CancellationToken cancellationToken)
+        {
+            string normalized = NormalizePhoneNumber(phoneNumber);
+
+            Profile? profile = await _profileRepo.GetByPhoneNumberAsync(normalized, cancellationToken);
+            if (profile is null)
+            {
+                return Error.NotFound("user_not_found", "User not found.");
+            }
+
+            var checkIns = await _dbContext.CheckInLocations
+                .Include(c => c.ProfileLocation)
+                .Where(c => c.ProfileLocation.ProfileId == profile.Id)
+                .ToListAsync(cancellationToken);
+
+            using MemoryStream zipStream = new();
+            using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, true))
+            {
+                ConcurrentQueue<string> csvLines = new();
+                csvLines.Enqueue("FileName,Latitude,Longitude");
+                int index = 0;
+                object zipLock = new();
+
+                await Parallel.ForEachAsync(checkIns, cancellationToken, async (checkIn, token) =>
+                {
+                    if (checkIn.ImageUrls is null)
+                        return;
+
+                    foreach (var url in checkIn.ImageUrls)
+                    {
+                        if (string.IsNullOrWhiteSpace(url))
+                            continue;
+
+                        var (bucket, name) = ParseGsUri(url);
+                        byte[] data = await _storageService.DownloadFileAsync(bucket, name, token);
+                        string extension = Path.GetExtension(name);
+                        int currentIndex = Interlocked.Increment(ref index);
+                        string entryName = $"image_{currentIndex}{extension}";
+
+                        lock (zipLock)
+                        {
+                            var entry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
+                            using var entryStream = entry.Open();
+                            entryStream.Write(data, 0, data.Length);
+                        }
+
+                        csvLines.Enqueue($"{entryName},{checkIn.ProfileLocation.Latitude},{checkIn.ProfileLocation.Longitude}");
+                    }
+                });
+
+                lock (zipLock)
+                {
+                    var csvEntry = archive.CreateEntry("locations.csv", CompressionLevel.Fastest);
+                    using var writer = new StreamWriter(csvEntry.Open(), Encoding.UTF8);
+                    foreach (var line in csvLines)
+                        writer.WriteLine(line);
+                }
+            }
+
+            return new ReportFile(zipStream.ToArray(), $"report_{normalized}.zip");
+        }
+
+        private static (string bucket, string name) ParseGsUri(string uri)
+        {
+            if (uri.StartsWith("gs://"))
+            {
+                string without = uri[5..];
+                int idx = without.IndexOf('/');
+                if (idx > -1)
+                {
+                    return (without[..idx], without[(idx + 1)..]);
+                }
+            }
+            throw new ArgumentException("Invalid Google Storage url", nameof(uri));
+        }
+
+        private static string NormalizePhoneNumber(string phoneNumber)
+        {
+            return phoneNumber.StartsWith("+966") ? phoneNumber[4..] : phoneNumber.StartsWith("0") ? phoneNumber[1..] : phoneNumber;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow downloading user data in a zip
- support downloading files from Google storage
- implement report generator service and endpoint
- register new ReportModule
- parallelize downloads in report generator

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*